### PR TITLE
Token requests should be sent without credentials

### DIFF
--- a/Examples/Scripts/cmi5Controller.js
+++ b/Examples/Scripts/cmi5Controller.js
@@ -289,7 +289,7 @@ var cmi5Controller = (function () {
             // We do not already have the auth token.  Make call to fetchUrl to get it.
             var myRequest = new XMLHttpRequest();
             myRequest.open("POST", cmi5Controller.fetchUrl, true);
-            myRequest.withCredentials = true;
+            myRequest.withCredentials = false;
             myRequest.onreadystatechange = function() {
                 if (this.readyState === 4) {
                     if (this.status === 200) {


### PR DESCRIPTION
There is no need to send the request for the token with credentials.

In Chrome and Safari sending XMLHttpRequests with credentials is not permitted when also using a wildcard in Access-Control-Allow-Origin.

Reference:
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials