### PR TITLE
Use a delay timeout when sending terminate

### DIFF
--- a/Examples/Scripts/cmi5Wrapper.js
+++ b/Examples/Scripts/cmi5Wrapper.js
@@ -2,7 +2,10 @@ function FinishAU() {
     // ToDo List: 
     // 1) Calculate duration
     SendStatement("Terminated");
-    cmi5Controller.goLMS();
+
+    // TODO: Need to wait for statement to be sent to LRS rather than using 
+    // timeout
+    setTimeout(function(){ cmi5Controller.goLMS(); }, 1000);
 }
 
 function SendStatement(verbName, score, duration, progress) {


### PR DESCRIPTION
Currently the terminate statement isn't sent because the browser is redirected back to LMS before the statement is sent.

This is a temporary solution. Perhaps someone can suggest a better solution.